### PR TITLE
Add a response wrapper that includes the headers from the API response.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 src/go*
 dist/go*
+.idea/

--- a/src/actions/create.js
+++ b/src/actions/create.js
@@ -12,6 +12,11 @@ export default class Create extends Mixin {
 
     const body = await this.client.api.post(this.createAction, options);
 
+    if (this.client.opts.includeHeadersInResponseWrapper) {
+      const response = body.response[this.resourceName];
+      return { headers: body.headers, response };
+    }
+
     return body[this.resourceName];
   }
 }

--- a/src/actions/create.js
+++ b/src/actions/create.js
@@ -12,7 +12,7 @@ export default class Create extends Mixin {
 
     const body = await this.client.api.post(this.createAction, options);
 
-    if (this.client.opts.includeHeadersInResponseWrapper) {
+    if (this.client.opts.responseOptions.includeHeaders) {
       const response = body.response[this.resourceName];
       return { headers: body.headers, response };
     }

--- a/src/actions/delete.js
+++ b/src/actions/delete.js
@@ -4,7 +4,7 @@ export default class Delete extends Mixin {
   async delete(id) {
     const body = await this.client.api.del(this.memberPath(id));
 
-    if (this.client.opts.includeHeadersInResponseWrapper) {
+    if (this.client.opts.responseOptions.includeHeaders) {
       const response = body.response[this.resourceName];
       return { headers: body.headers, response };
     }

--- a/src/actions/delete.js
+++ b/src/actions/delete.js
@@ -4,6 +4,11 @@ export default class Delete extends Mixin {
   async delete(id) {
     const body = await this.client.api.del(this.memberPath(id));
 
+    if (this.client.opts.includeHeadersInResponseWrapper) {
+      const response = body.response[this.resourceName];
+      return { headers: body.headers, response };
+    }
+
     return body[this.resourceName];
   }
 }

--- a/src/actions/find.js
+++ b/src/actions/find.js
@@ -4,6 +4,11 @@ export default class Find extends Mixin {
   async find(id) {
     const body = await this.client.api.get(this.memberPath(id));
 
+    if (this.client.opts.includeHeadersInResponseWrapper) {
+      const response = body.response[this.resourceName];
+      return { headers: body.headers, response };
+    }
+
     return body[this.resourceName];
   }
 }

--- a/src/actions/find.js
+++ b/src/actions/find.js
@@ -4,7 +4,7 @@ export default class Find extends Mixin {
   async find(id) {
     const body = await this.client.api.get(this.memberPath(id));
 
-    if (this.client.opts.includeHeadersInResponseWrapper) {
+    if (this.client.opts.responseOptions.includeHeaders) {
       const response = body.response[this.resourceName];
       return { headers: body.headers, response };
     }

--- a/src/actions/list.js
+++ b/src/actions/list.js
@@ -15,7 +15,7 @@ export default class List extends Mixin {
 
     const body = await this.client.api.get(this.collectionPath(), options);
 
-    if (this.client.opts.includeHeadersInResponseWrapper) {
+    if (this.client.opts.responseOptions.includeHeaders) {
       const response = new Page(body.response, this.resourcesName);
       return { headers: body.headers, response };
     }

--- a/src/actions/list.js
+++ b/src/actions/list.js
@@ -14,6 +14,12 @@ export default class List extends Mixin {
     };
 
     const body = await this.client.api.get(this.collectionPath(), options);
+
+    if (this.client.opts.includeHeadersInResponseWrapper) {
+      const response = new Page(body.response, this.resourcesName);
+      return { headers: body.headers, response };
+    }
+
     return new Page(body, this.resourcesName);
   }
 }

--- a/src/actions/update.js
+++ b/src/actions/update.js
@@ -8,6 +8,11 @@ export default class Update extends Mixin {
 
     const body = await this.client.api.put(this.memberPath(id), options);
 
+    if (this.client.opts.includeHeadersInResponseWrapper) {
+      const response = body.response[this.resourceName];
+      return { headers: body.headers, response };
+    }
+
     return body[this.resourceName];
   }
 }

--- a/src/actions/update.js
+++ b/src/actions/update.js
@@ -8,7 +8,7 @@ export default class Update extends Mixin {
 
     const body = await this.client.api.put(this.memberPath(id), options);
 
-    if (this.client.opts.includeHeadersInResponseWrapper) {
+    if (this.client.opts.responseOptions.includeHeaders) {
       const response = body.response[this.resourceName];
       return { headers: body.headers, response };
     }

--- a/src/client.js
+++ b/src/client.js
@@ -25,6 +25,7 @@ const BASE_URL = 'https://api.fulcrumapp.com/api/v2';
 export default class Client {
   constructor(token, opts) {
     const _opts = opts || {};
+    this.opts = _opts;
 
     this.baseUrl = _opts.baseUrl || BASE_URL;
 
@@ -36,7 +37,8 @@ export default class Client {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
         'User-Agent': _opts.userAgent || `fulcrum-js version ${VERSION}`
-      }
+      },
+      includeHeadersInResponseWrapper: _opts.includeHeadersInResponseWrapper
     };
 
     const tokenOptions = Object.assign({}, options);

--- a/src/client.js
+++ b/src/client.js
@@ -24,7 +24,7 @@ const BASE_URL = 'https://api.fulcrumapp.com/api/v2';
 
 export default class Client {
   constructor(token, opts) {
-    const _opts = opts || {};
+    const _opts = opts || { responseOptions: { includeHeaders: false }};
     this.opts = _opts;
 
     this.baseUrl = _opts.baseUrl || BASE_URL;
@@ -38,7 +38,7 @@ export default class Client {
         'Content-Type': 'application/json',
         'User-Agent': _opts.userAgent || `fulcrum-js version ${VERSION}`
       },
-      includeHeadersInResponseWrapper: _opts.includeHeadersInResponseWrapper
+      includeHeadersInResponseWrapper: _opts.responseOptions.includeHeaders === true
     };
 
     const tokenOptions = Object.assign({}, options);


### PR DESCRIPTION
Adds a new option to the client creation.

	  { 
	  	responseOptions: {
           includeHeaders: true
        }
	  }


With this option set to true, the responses will then be wrapped with an object that includes a field for the headers.

includeHeaders: true results in

	  {
	      headers: { ... },
	      response: OLDRESPONSETYPE
	  }


includedHeaders: false results in previous behavior of

     {
        OLDRESPONSETYPE
     }



This change is made primarily for easy access to the response headers on a successful request.  This allows us to get the rate limit headers for usage in our applications.


Some notes: The client currently checks for a failed request and throws an error immediately which means we can't get any header information back in that specific case.