### PR TITLE
fix: replace invalid CODEOWNERS `@fulcrumapp/custom-apps-and-reporting` with `@fulcrumapp/car-web`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @fulcrumapp/custom-apps-and-reporting
+* @fulcrumapp/car-web


### PR DESCRIPTION
This PR fixes the CODEOWNERS file which referenced a non-existent team `@fulcrumapp/custom-apps-and-reporting`.

- Replaces `@fulcrumapp/custom-apps-and-reporting` with `@fulcrumapp/car-web` (valid team `car-web`).
- Validated against `gh api /orgs/fulcrumapp/teams` (24 teams, `custom-apps-and-reporting` not found, 404).

Fixes audit finding that `@fulcrumapp/custom-apps-and-reporting` does not exist in the org.